### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax/block.php
+++ b/syntax/block.php
@@ -27,7 +27,7 @@ class syntax_plugin_poem_block extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         if ($state==DOKU_LEXER_UNMATCHED) {
             $handler->_addCall('cdata', array($match), $pos);
         }
@@ -37,5 +37,5 @@ class syntax_plugin_poem_block extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    function render($format, &$renderer, $data) {}
+    function render($format, Doku_Renderer $renderer, $data) {}
 }

--- a/syntax/eol.php
+++ b/syntax/eol.php
@@ -22,12 +22,12 @@ class syntax_plugin_poem_eol extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler){return true;}
+    function handle($match, $state, $pos, Doku_Handler $handler){return true;}
 
     /**
      * Create output
      */
-    function render($format, &$renderer, $data) {
+    function render($format, Doku_Renderer $renderer, $data) {
         if($format == 'xhtml'){
             $renderer->doc .= "<br/>\n";
             return true;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
