### PR TITLE
Fix method signature compatibility warnings for PHP7.0

### DIFF
--- a/syntax/block.php
+++ b/syntax/block.php
@@ -27,7 +27,7 @@ class syntax_plugin_poem_block extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         if ($state==DOKU_LEXER_UNMATCHED) {
             $handler->_addCall('cdata', array($match), $pos);
         }
@@ -37,5 +37,5 @@ class syntax_plugin_poem_block extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    function render($format, &$renderer, $data) {}
+    function render($format, Doku_Renderer $renderer, $data) {}
 }

--- a/syntax/eol.php
+++ b/syntax/eol.php
@@ -22,12 +22,12 @@ class syntax_plugin_poem_eol extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler){return true;}
+    function handle($match, $state, $pos, Doku_Handler $handler){return true;}
 
     /**
      * Create output
      */
-    function render($format, &$renderer, $data) {
+    function render($format, Doku_Renderer $renderer, $data) {
         if($format == 'xhtml'){
             $renderer->doc .= "<br/>\n";
             return true;


### PR DESCRIPTION
This is to fix the method signature warning messages for PHP7.0. Dokuwiki shows the following warnings without the fix:

Warning: Declaration of syntax_plugin_poem_block::handle($match, $state, $pos, &$handler) should be compatible with DokuWiki_Syntax_Plugin::handle($match, $state, $pos, Doku_Handler $handler) in /volume1/web/dokuwiki/lib/plugins/poem/syntax/block.php on line 0

Warning: Declaration of syntax_plugin_poem_block::render($format, &$renderer, $data) should be compatible with DokuWiki_Syntax_Plugin::render($format, Doku_Renderer $renderer, $data) in /volume1/web/dokuwiki/lib/plugins/poem/syntax/block.php on line 0

Warning: Declaration of syntax_plugin_poem_eol::handle($match, $state, $pos, &$handler) should be compatible with DokuWiki_Syntax_Plugin::handle($match, $state, $pos, Doku_Handler $handler) in /volume1/web/dokuwiki/lib/plugins/poem/syntax/eol.php on line 0

Warning: Declaration of syntax_plugin_poem_eol::render($format, &$renderer, $data) should be compatible with DokuWiki_Syntax_Plugin::render($format, Doku_Renderer $renderer, $data) in /volume1/web/dokuwiki/lib/plugins/poem/syntax/eol.php on line 0

I tested and it seemed working for me. However this is my first time touching any php code so not really confident about it.
